### PR TITLE
fix: add and preserve favorite quotes

### DIFF
--- a/Controllers/UsersController.cs
+++ b/Controllers/UsersController.cs
@@ -181,6 +181,7 @@ namespace ProgrammingQuotesApi.Controllers
             if (user == null) return NotFound();
 
             _userService.addFavoriteQuote(user, quote);
+
             return Ok(user);
         }
     }

--- a/Models/User.cs
+++ b/Models/User.cs
@@ -31,6 +31,6 @@ namespace ProgrammingQuotesApi.Models
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Populate)]
         public string Role { get; set; }
 
-        public HashSet<Quote> favoriteQuotes { get; set; } = new HashSet<Quote>();
+        public HashSet<Quote> FavoriteQuotes { get; set; } = new HashSet<Quote>();
     }
 }

--- a/Properties/launchSettings.json
+++ b/Properties/launchSettings.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "$schema": "http://json.schemastore.org/launchsettings.json",
   "iisSettings": {
     "windowsAuthentication": false,
@@ -12,16 +12,13 @@
     "IIS Express": {
       "commandName": "IISExpress",
       "launchBrowser": true,
-      "launchUrl": "",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
     "ProgrammingQuotesApi": {
       "commandName": "Project",
-      "dotnetRunMessages": true,
       "launchBrowser": true,
-      "launchUrl": "",
       "applicationUrl": "https://localhost:5001;http://localhost:5000",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"

--- a/Services/UserService.cs
+++ b/Services/UserService.cs
@@ -4,6 +4,7 @@ using ProgrammingQuotesApi.Helpers;
 using ProgrammingQuotesApi.Models;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.EntityFrameworkCore;
 
 namespace ProgrammingQuotesApi.Services
 {
@@ -28,13 +29,13 @@ namespace ProgrammingQuotesApi.Services
             return response;
         }
 
-        public IEnumerable<User> GetAll() => _context.Users;
+        public IEnumerable<User> GetAll() => _context.Users.Include(u => u.FavoriteQuotes);
 
-        public User GetById(int id) => _context.Users.FirstOrDefault(p => p.Id == id);
+        public User GetById(int id) => _context.Users.Include(u => u.FavoriteQuotes).FirstOrDefault(p => p.Id == id);
 
         public User GetByUsername(string username)
         {
-            User user = _context.Users.FirstOrDefault(x => x.Username.ToLower() == username.ToLower());
+            User user = _context.Users.Include(u => u.FavoriteQuotes).FirstOrDefault(x => x.Username.ToLower() == username.ToLower());
             if (user == null) return null;
 
             return user;
@@ -80,8 +81,7 @@ namespace ProgrammingQuotesApi.Services
 
         public void addFavoriteQuote(User user, Quote quote)
         {
-            user.favoriteQuotes.Add(quote);
-            _context.Users.Update(user);
+            user.FavoriteQuotes.Add(quote);
             _context.SaveChanges();
         }
 


### PR DESCRIPTION
Solves issue #49 

Hey, 

Just added a fix for preserving the favorite quotes. Reading tons of documentation made it clear that we need to explicitly include the "FavoriteQuotes" property while retrieving the User from the _context. So I have added bunch of "Include(u => u.FavoriteQuotes)" in the userService class. 
Please have a look into it.

Thanks, 
Anirud

Screenshot:
![image](https://github.com/mudroljub/programming-quotes-api/assets/71384179/ed2a5b17-696c-4466-95ff-a4184dcc3b0e)
